### PR TITLE
Remove an unnecessary permission from the manifest

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,51 +1,50 @@
 {
-	"manifest_version": 2,
+  "manifest_version": 2,
 
-	"name": "Gmail Template and Snippet manager",
-	"version": "1.2.2",
-	"description": "Insert predefined mails: Create email templates and re-use them. Stop copy-pasting and boost your productivity with this app.",
-	"short_name":"Manage your gmail templates easily. Bulk email sending.",
-	"update_url": "https://clients2.google.com/service/update2/crx",
-	"permissions": [
-		"tabs",
-		"http://mail.google.com/*",
-    	"https://mail.google.com/",
-    	"http://*/"
-	],
-	"content_security_policy": "default-src 'none'; style-src 'self'; script-src 'self'; connect-src https://api.parse.com",
-	"icons": {
-		"16": "img/icon_16.png",
-		"32": "img/icon_32.png",
-		"48": "img/icon_48.png"
-	},
-	"web_accessible_resources": [
-		"lib/bootstrap.js",
-		"lib/gmailr.js",
-		"lib/init.js",
-		"lib/jquery.min.js",
-		"lib/jquery.min.map",
-		"lib/jquery.ba-bbq.js",
-		"lib/lab.js",
-		"lib/parse-1.3.3.min.js",
-		"lib/jquery.jqote2.min.js",
-        "lib/openpgp.worker.js",
-        "lib/openpgp.js",
-		"img/delete.png",
-		"img/save.png",
-		"img/edit.png",
-		"img/gmail.png",
-		"main.css",
-		"main.js",
-		"template-list.jqote",
-		"template-update.jqote",
-		"lib/ckeditor/ckeditor.js",
-		"lib/ckeditor/adapters/jquery.js",
-		"lib/ckeditor/*"
-	],		
-	"content_scripts": [{
-		"matches": [ "http://mail.google.com/*", "https://mail.google.com/*" ],
-	    "js": ["lib/bootstrap.js"],
-	    "run_at": "document_end"
-	}]
+  "name": "Gmail Template and Snippet manager",
+  "version": "1.2.2",
+  "description": "Insert predefined mails: Create email templates and re-use them. Stop copy-pasting and boost your productivity with this app.",
+  "short_name":"Manage your gmail templates easily. Bulk email sending.",
+  "update_url": "https://clients2.google.com/service/update2/crx",
+  "permissions": [
+    "tabs",
+    "http://mail.google.com/*",
+    "https://mail.google.com/"
+  ],
+  "content_security_policy": "default-src 'none'; style-src 'self'; script-src 'self'; connect-src https://api.parse.com",
+  "icons": {
+    "16": "img/icon_16.png",
+    "32": "img/icon_32.png",
+    "48": "img/icon_48.png"
+  },
+  "web_accessible_resources": [
+    "lib/bootstrap.js",
+    "lib/gmailr.js",
+    "lib/init.js",
+    "lib/jquery.min.js",
+    "lib/jquery.min.map",
+    "lib/jquery.ba-bbq.js",
+    "lib/lab.js",
+    "lib/parse-1.3.3.min.js",
+    "lib/jquery.jqote2.min.js",
+    "lib/openpgp.worker.js",
+    "lib/openpgp.js",
+    "img/delete.png",
+    "img/save.png",
+    "img/edit.png",
+    "img/gmail.png",
+    "main.css",
+    "main.js",
+    "template-list.jqote",
+    "template-update.jqote",
+    "lib/ckeditor/ckeditor.js",
+    "lib/ckeditor/adapters/jquery.js",
+    "lib/ckeditor/*"
+  ],
+  "content_scripts": [{
+    "matches": [ "http://mail.google.com/*", "https://mail.google.com/*" ],
+    "js": ["lib/bootstrap.js"],
+    "run_at": "document_end"
+  }]
 }
 


### PR DESCRIPTION
The permission removed is for "http://*/"

Also replaces the tabs with spaces so that there is no longer a mixture of tabs and spaces