### PR TITLE
changes to make subject and body both use the same template variable values

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -367,8 +367,8 @@ var enrich = function(content, mail, reset=false) {
   for (i = 0; i < tokens.length; i++) {
     try {
       var split = tokens[i][1].split(":");
-      if (ss[split[0]] == null) ss[split[0]] = {};
-      s = ss[split[0]];
+      if (subs[split[0]] == null) subs[split[0]] = {};
+      s = subs[split[0]];
       if (s.val == null) {
         s.val = prompt(split[2]);
       }

--- a/source/main.js
+++ b/source/main.js
@@ -29,6 +29,7 @@ Gmailr.debug = false; // Turn verbose debugging messages on
 
 Gmailr.init(function(G) {
   var email = G.emailAddress();
+  var tokens = []; // equivalent of static variable so it can last over multiple calls to enrich()
   window.usage.lang = G.language() || "undefined";
   window.usage.ginbox = (!!G.isGinbox())?"ginbox":"gmail";
 
@@ -221,7 +222,7 @@ Gmailr.init(function(G) {
     var insertTemplate = function(template, button) {
       // Find the subject box and insert the subject
       var pre_subject = template.get("subject");
-      var subject = enrich(pre_subject,email);
+      var subject = enrich(pre_subject,email,true); // last parameter resets the tokens array
       if (subject) {
         var subjectBox;
         var subjectSelector = G.isGinbox()?'input[placeholder="Subject"]':'input[name="subjectbox"]';
@@ -350,9 +351,10 @@ jQuery.fn.center = function() {
   return this;
 };
 
-var enrich = function(content, mail) {
+var enrich = function(content, mail, reset=false) {
+  if (reset) // use when doing the subject line to start a new message
+    tokens = [];
   var r = /\${([^\$]*)}/g;
-  var tokens = [];
   var match = r.exec(content);
   while (match != null) {
     tokens.push(match);

--- a/source/main.js
+++ b/source/main.js
@@ -29,7 +29,7 @@ Gmailr.debug = false; // Turn verbose debugging messages on
 
 Gmailr.init(function(G) {
   var email = G.emailAddress();
-  var tokens = []; // equivalent of static variable so it can last over multiple calls to enrich()
+  var subs = {}; // equivalent of static variable so it can last over multiple calls to enrich()
   window.usage.lang = G.language() || "undefined";
   window.usage.ginbox = (!!G.isGinbox())?"ginbox":"gmail";
 
@@ -352,19 +352,18 @@ jQuery.fn.center = function() {
 };
 
 var enrich = function(content, mail, reset=false) {
-  if (reset) // use when doing the subject line to start a new message
-    tokens = [];
   var r = /\${([^\$]*)}/g;
   var match = r.exec(content);
   while (match != null) {
     tokens.push(match);
     match = r.exec(content);
   }
-  var ss = {
-    "me": {
-      "val": mail
-    }
-  };
+  if (reset) // use when doing the subject line to start a new message
+    subs = {
+      "me": {
+        "val": mail
+      }
+    };
   for (i = 0; i < tokens.length; i++) {
     try {
       var split = tokens[i][1].split(":");

--- a/source/main.js
+++ b/source/main.js
@@ -353,6 +353,7 @@ jQuery.fn.center = function() {
 
 var enrich = function(content, mail, reset=false) {
   var r = /\${([^\$]*)}/g;
+  var tokens = [];
   var match = r.exec(content);
   while (match != null) {
     tokens.push(match);

--- a/source/main.js
+++ b/source/main.js
@@ -220,7 +220,8 @@ Gmailr.init(function(G) {
     }
     var insertTemplate = function(template, button) {
       // Find the subject box and insert the subject
-      var subject = template.get("subject");
+      var pre_subject = template.get("subject");
+      var subject = enrich(pre_subject,email);
       if (subject) {
         var subjectBox;
         var subjectSelector = G.isGinbox()?'input[placeholder="Subject"]':'input[name="subjectbox"]';


### PR DESCRIPTION
My apologies for how sloppy I was with git -- I didn't feel like cloning to my machine and working there, and I should have, so here we are with five commits for a trivial change.

Anyway, this makes it possible to put e.g. ${1:text:Someone's name} in the subject line then use ${1} in the body and have it remain consistent.  The values are cleared out the next time a subject line is enriched (i.e. new message.)  Seems to work.
